### PR TITLE
Support secure https connectiontions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Variable | Description
 `filter` | An array of filter rules. See [filtering sessions](#filtering-sessions)
 `polling_interval` | Interval in seconds in which the play state is checked. Default is `3`, lower values are discuraged.
 `debug` | Set this to true to receive detailed debug information about active sessions and filtering. This is not recommended for permanent installations as it fills up your log files pretty quickly.
+`secure` | Set this to true if your Plex has Secure connections: **Required**. Defaults to `false` which will work with Preferred or Disabled.
 
 Typical config example:
 ```json

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class Plex {
     this.plexToken = config.plex_token;
     this.host = config.host || 'localhost';
     this.port = config.port || '32400';
+    this.secure = config.secure || false;
     this.filter = config.filter || [];
     this.pollingInterval = config.polling_interval * 1000 || 3000;
     this.debug = config.debug || false;
@@ -45,7 +46,8 @@ class Plex {
 
   getState(callback) {
     const options = {
-      url: `http://${this.host}:${this.port}/status/sessions`,
+      url: `http${this.secure ? "s" : ""}://${this.host}:${this.port}/status/sessions`,
+      rejectUnauthorized: false, // Plex certificates are not signed for a nice hostname / IP
       headers: {
         'Accept': 'application/json',
         'X-Plex-Token': this.plexToken

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class Plex {
 
   getState(callback) {
     const options = {
-      url: `http${this.secure ? "s" : ""}://${this.host}:${this.port}/status/sessions`,
+      url: `http${this.secure ? 's' : ''}://${this.host}:${this.port}/status/sessions`,
       rejectUnauthorized: false, // Plex certificates are not signed for a nice hostname / IP
       headers: {
         'Accept': 'application/json',


### PR DESCRIPTION
This adds an option to support the `https:` secure connection, and adds the required override for the certificate signing (Plex signs itself for a very user-unfriendly hostname that isn't guaranteed to be static).

Still needs README changes for the `secure: true` option, but this is the important bit ;-)